### PR TITLE
Fix animations in nav

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -160,9 +160,10 @@ body > header a {
 	
 	position: relative;
 	transition: all 0.3s ease;
+	display: inline-block;
 }
 body > header a:link:hover {
-	bottom: 3px;
+	transform: translateY(-3px);
 }
 body > header > a:first-child {
 	font-size: 26px;
@@ -176,10 +177,10 @@ body > header > a:first-child::before {
 	background-size: 48px;
 	vertical-align: -14px;
 	margin-right: 4px;
+	transition: transform 0.67s ease;
 }
 body > header > a:first-child:hover::before {
 	transform: rotate(-360deg);
-	transition: transform 0.67s ease;
 }
 body > header > nav {
 	text-align: right;


### PR DESCRIPTION
This fixes the missing animation of the nav links by adding the `display: inline-block` property to the links, and also uses the `transform` property instead of `bottom` property to avoid layout calculations.

This also fixes the logo spinning animation abruptly snapping back when the cursor leaves the bounding box in the middle of the animation by moving the `transform` property from the `:hover::before` state to the `::before` pseudo-element itself - such that when the cursor leaves the bounding box during the animation, the animation reverses gracefully to the original position instead. 

TL;DR: fixes navigation links' animations, fixes logo icon animation