### PR TITLE
Fix tooltip

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -48,6 +48,7 @@ function setupTooltip(el, options) {
 		document.body.insertAdjacentHTML('beforeend',
 			'<dialog role="tooltip"></dialog>');
 		tooltip = document.querySelector('body > dialog[role=tooltip]');
+		tooltip.open = true
 		
 		// title
 		title = title.replace(/ \(([^()]+?)\)$/gi, ' <span>($1)</span>')
@@ -93,9 +94,6 @@ function setupTooltip(el, options) {
 		
 		tooltip.style.top = (e.pageY - tooltip.clientHeight - 30) + 'px';
 		tooltip.style.left = (leftPos - 8) + 'px';
-		
-		// fukidashi position
-		tooltip.querySelector('div').style.left = (e.pageX - leftPos) + 'px';
 	});
 }
 


### PR DESCRIPTION
Noticed the tooltip is not working because it is missing [the `[open]` attribute of `<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#open).

Also noticed the "fukidashi position" part is erroring out and does nothing after fixing it, so I just removed it. If it is supposed to do something please let me know.

<img width="261" alt="Screenshot 2023-10-02 at 21 54 43" src="https://github.com/coteditor/coteditor.github.io/assets/44045911/ee06991c-0499-46f3-b8fd-f4e7d50eaabe">
